### PR TITLE
Fixed an obscure bug for models with multiple group fields, when updating and only specifying one.

### DIFF
--- a/models/behaviors/sequence.php
+++ b/models/behaviors/sequence.php
@@ -488,7 +488,7 @@ class SequenceBehavior extends ModelBehavior {
 
     foreach ($groupFields as $groupField => $escapedGroupField) {
 
-      if (isset($model->data[$model->alias][$groupField])) {
+      if (array_key_exists($groupField,$model->data[$model->alias])) {
 
         $this->_newGroups[$model->alias][$groupField] = $model->data[$model->alias][$groupField];
 

--- a/models/behaviors/sequence.php
+++ b/models/behaviors/sequence.php
@@ -235,12 +235,12 @@ class SequenceBehavior extends ModelBehavior {
 
       // No action if new and old group and order same
       if ($this->_newOrder[$model->alias] == $this->_oldOrder[$model->alias]
-      && Set::isEqual($this->_newGroups[$model->alias], $this->_oldGroups[$model->alias])) {
+      && $this->_newGroups[$model->alias] == $this->_oldGroups[$model->alias]) {
         return;
       }
 
       // If changing group
-      if ($this->_newGroups[$model->alias] && !Set::isEqual($this->_newGroups[$model->alias], $this->_oldGroups[$model->alias])) {
+      if ($this->_newGroups[$model->alias] && $this->_newGroups[$model->alias] != $this->_oldGroups[$model->alias]) {
 
         // Decrement records in old group with higher order than moved record old order
         $this->_update[$model->alias][] = array(

--- a/models/behaviors/sequence.php
+++ b/models/behaviors/sequence.php
@@ -492,6 +492,10 @@ class SequenceBehavior extends ModelBehavior {
 
         $this->_newGroups[$model->alias][$groupField] = $model->data[$model->alias][$groupField];
 
+      } elseif ($model->id) {
+
+        $this->_newGroups[$model->alias][$groupField] = $model->field($groupField);
+
       }
 
     }

--- a/tests/cases/behaviors/sequence.test.php
+++ b/tests/cases/behaviors/sequence.test.php
@@ -580,6 +580,36 @@ class SequenceBehaviorMultiGroupTestCase extends CakeTestCase {
      );
     $this->assertEqual($results, $expected);
   }
+  
+  function testEditGroupMoveToNull() {
+    $MultiGroupedItem = new MultiGroupedItem();
+    $MultiGroupedItem->save(array(
+      'MultiGroupedItem' => array(
+        'id' => '3',
+        'group_field_2' => null,
+      )
+    ));
+    $results = $MultiGroupedItem->find('all', array('conditions' => array(
+      'OR' => array(
+        array(
+          'group_field_1' => 1,
+          'group_field_2' => 1
+        ),
+        array(
+          'group_field_1' => 1,
+          'group_field_2' => null
+        )
+      )
+    ), 'order' => '`MultiGroupedItem`.`group_field_1`, `MultiGroupedItem`.`group_field_2`, `MultiGroupedItem`.`order`'));
+    $expected = array(
+       array('MultiGroupedItem' => array('id' => 3, 'name' => 'Group1 1 Group2 1 Item C', 'group_field_1' => 1, 'group_field_2' => null, 'order' => 0)),
+      array('MultiGroupedItem' => array('id' => 1, 'name' => 'Group1 1 Group2 1 Item A', 'group_field_1' => 1, 'group_field_2' => 1, 'order' => 0)),
+       array('MultiGroupedItem' => array('id' => 2, 'name' => 'Group1 1 Group2 1 Item B', 'group_field_1' => 1, 'group_field_2' => 1, 'order' => 1)),
+       array('MultiGroupedItem' => array('id' => 4, 'name' => 'Group1 1 Group2 1 Item D', 'group_field_1' => 1, 'group_field_2' => 1, 'order' => 2)),
+       array('MultiGroupedItem' => array('id' => 5, 'name' => 'Group1 1 Group2 1 Item E', 'group_field_1' => 1, 'group_field_2' => 1, 'order' => 3)),
+     );
+    $this->assertEqual($results, $expected);
+  }
 
 
 }

--- a/tests/cases/behaviors/sequence.test.php
+++ b/tests/cases/behaviors/sequence.test.php
@@ -546,5 +546,41 @@ class SequenceBehaviorMultiGroupTestCase extends CakeTestCase {
 		$this->assertEqual($results, $expected);
   }
 
+  function testEditPartialGroupSpecified() {
+    $MultiGroupedItem = new MultiGroupedItem();
+    $MultiGroupedItem->save(array(
+      'MultiGroupedItem' => array(
+        'id' => '3',
+        'group_field_2' => '2',
+      )
+    ));
+    $results = $MultiGroupedItem->find('all', array('conditions' => array(
+      'OR' => array(
+        array(
+          'group_field_1' => 1,
+          'group_field_2' => 1
+        ),
+        array(
+          'group_field_1' => 1,
+          'group_field_2' => 2
+        )
+      )
+    ), 'order' => '`MultiGroupedItem`.`group_field_1`, `MultiGroupedItem`.`group_field_2`, `MultiGroupedItem`.`order`'));
+    $expected = array(
+      array('MultiGroupedItem' => array('id' => 1, 'name' => 'Group1 1 Group2 1 Item A', 'group_field_1' => 1, 'group_field_2' => 1, 'order' => 0)),
+       array('MultiGroupedItem' => array('id' => 2, 'name' => 'Group1 1 Group2 1 Item B', 'group_field_1' => 1, 'group_field_2' => 1, 'order' => 1)),
+       array('MultiGroupedItem' => array('id' => 4, 'name' => 'Group1 1 Group2 1 Item D', 'group_field_1' => 1, 'group_field_2' => 1, 'order' => 2)),
+       array('MultiGroupedItem' => array('id' => 5, 'name' => 'Group1 1 Group2 1 Item E', 'group_field_1' => 1, 'group_field_2' => 1, 'order' => 3)),
+       array('MultiGroupedItem' => array('id' => 6, 'name' => 'Group1 1 Group2 2 Item A', 'group_field_1' => 1, 'group_field_2' => 2, 'order' => 0)),
+       array('MultiGroupedItem' => array('id' => 7, 'name' => 'Group1 1 Group2 2 Item B', 'group_field_1' => 1, 'group_field_2' => 2, 'order' => 1)),
+       array('MultiGroupedItem' => array('id' => 8, 'name' => 'Group1 1 Group2 2 Item C', 'group_field_1' => 1, 'group_field_2' => 2, 'order' => 2)),
+       array('MultiGroupedItem' => array('id' => 9, 'name' => 'Group1 1 Group2 2 Item D', 'group_field_1' => 1, 'group_field_2' => 2, 'order' => 3)),
+       array('MultiGroupedItem' => array('id' => 10, 'name' => 'Group1 1 Group2 2 Item E', 'group_field_1' => 1, 'group_field_2' => 2, 'order' => 4)),
+       array('MultiGroupedItem' => array('id' => 3, 'name' => 'Group1 1 Group2 1 Item C', 'group_field_1' => 1, 'group_field_2' => 2, 'order' => 5)),
+     );
+    $this->assertEqual($results, $expected);
+  }
+
+
 }
 ?>


### PR DESCRIPTION
Fixed a bug where order wasn't updated correctly if a model has multiple grouping fields, and not all of them were specified during an update.

Also included is a separate commit with the cake 1.3 compatibility fixes.
